### PR TITLE
Blackarch-Installer needs a working internet connection

### DIFF
--- a/blackarch-install
+++ b/blackarch-install
@@ -1232,15 +1232,14 @@ setup_base_system()
     setup_resolvconf
     sleep_clear 1
 
-    install_base_packages
-    sleep_clear 1
-
     if [ "${INSTALL_MODE}" = "${INSTALL_LIVE_ISO}" ]
     then
         dump_live_iso
-        sleep_clear 1
+    else
+        install_base_packages
     fi
-
+    sleep_clear 1
+    
     setup_resolvconf
     sleep_clear 1
 


### PR DESCRIPTION
Is it nesseccary that the live iso dump mode needs a working internet connection?

Maybe its a bug and this [line 1235](https://github.com/BlackArch/blackarch-installer/blob/master/blackarch-install#L1235) should go to an else case.

If I'm wrong feel free to discard this PR.

Thanks!
