### PR TITLE
update sha1

### DIFF
--- a/blackarch-install
+++ b/blackarch-install
@@ -1356,8 +1356,7 @@ ask_mirror()
 run_strap_sh()
 {
     strap_sh="/tmp/strap.sh"
-    orig_sha1="c7012b890bb6043a2b39ca749cf0dbb9daac606c"
-    #orig_sha1="86eb4efb68918dbfdd1e22862a48fda20a8145ff"
+    orig_sha1="34b1a3698a4c971807fb1fe41463b9d25e1a4a09"
 
     title "BlackArch Linux Setup"
 


### PR DESCRIPTION
Hi folks,

as @noptrix [mentioned](https://github.com/BlackArch/blackarch-site/pull/35), this updates the sha1 sum for `blackarch-installer`. Please also note his [remarks about not merging the changes immediately](https://github.com/BlackArch/blackarch-site/pull/35#issuecomment-241699238).

I hope it's ok to remove the comment line, I guess it's the last release's sha1.

Cheers.
