### PR TITLE
Update efivars check

### DIFF
--- a/blackarch-install
+++ b/blackarch-install
@@ -254,7 +254,8 @@ banner()
 # check boot mode
 check_boot_mode()
 {
-  if [ "$(efivar --list 2> /dev/null)" ]
+  efivars=$(ls /sys/firmware/efi/efivars > /dev/null 2>&1; echo $?)
+  if [ "$efivars" -eq "0" ]
   then
      BOOT_MODE="uefi"
   fi

--- a/blackarch-install
+++ b/blackarch-install
@@ -10,7 +10,7 @@
 
 
 # blackarch-installer version
-VERSION='1.2.22'
+VERSION='1.2.23'
 
 # path to blackarch-installer
 BI_PATH='/usr/share/blackarch-installer'


### PR DESCRIPTION
Update the check for efivars to be independent from the `efivar` tool.
This is also they way the ArchWiki recommends and @FallenChromium mentioned in
#70 

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>