### PR TITLE
Fixed keyring errors

### DIFF
--- a/blackarch-install
+++ b/blackarch-install
@@ -2460,9 +2460,6 @@ main()
   check_boot_mode
   check_iso_type
 
-  # Update keyrings
-  install_keyrings
-
   # install mode
   ask_install_mode
 
@@ -2512,6 +2509,9 @@ main()
     sleep_clear 1
     check_inet_conn
     sleep_clear 1
+
+    # Update keyrings
+    install_keyrings
 
     # self updater
     self_updater


### PR DESCRIPTION
#79 isn't in fact fully fixed. #82 Updates the keyrings, but it assumes that there's already an internet connection, so It fails if there isn't.

I moved it so it only runs when there's a connection.